### PR TITLE
another fix for data-processing-op args syntax, and data_dir for training

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -442,7 +442,7 @@ def gen_standalone():
 
     # The list of executor names to extract details from to generate the standalone script
     executors = {
-        "exec-data-processing-op": 'data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_SDG_PATH}", processed_data="{PREPROCESSED_DATA_PATH}")',
+        "exec-data-processing-op": 'data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_MODEL_PATH}", processed_data="{PREPROCESSED_DATA_PATH}")',
         "exec-sdg-op": 'sdg_op(num_instructions_to_generate={num_instructions_to_generate}, repo_branch="{exec_git_clone_op_repo_branch}", repo_pr={exec_git_clone_op_repo_pr}, taxonomy="{TAXONOMY_DATA_PATH}", sdg="{SDG_GENERATED_DATA_PATH}")',
         "exec-git-clone-op": {},
         "exec-huggingface-importer-op": 'huggingface_importer_op(repo_name="{REPO_GRANITE_7B_IMAGE}", model="{DATA_PVC_MODEL_PATH}")',

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -221,7 +221,7 @@ spec:
                     --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT) \
                     -m instructlab.training.main_ds \
                     --model_name_or_path="$PATH_TO_MODEL" \
-                    --data_path=/data/processed_data/data.jsonl \
+                    --data_path=/data/data/processed_data/data.jsonl \
                     --output_dir="$tmp_model" \
                     --num_epochs={epoch_num} \
                     --effective_batch_size=3840 \

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -1166,7 +1166,7 @@ def data_processing_op(
     data_processing(train_args=training_args)
 """
     exec_data_processing_op_args = f"""
-data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_SDG_PATH}", processed_data="{PREPROCESSED_DATA_PATH}")
+data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_MODEL_PATH}", processed_data="{PREPROCESSED_DATA_PATH}")
 """
 
     init_containers = [
@@ -1383,7 +1383,7 @@ def data_processing_op(
     data_processing(train_args=training_args)
 """
     exec_data_processing_op_args = f"""
-data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg={DATA_PVC_SDG_PATH}, model={DATA_PVC_SDG_PATH}, processed_data={PREPROCESSED_DATA_PATH})
+data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_MODEL_PATH}", processed_data="{PREPROCESSED_DATA_PATH}")
 """
 
     data_container = kubernetes.client.V1Container(

--- a/standalone/standalone.tpl
+++ b/standalone/standalone.tpl
@@ -206,7 +206,7 @@ spec:
                     --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT) \
                     -m instructlab.training.main_ds \
                     --model_name_or_path="$PATH_TO_MODEL" \
-                    --data_path=/data/processed_data/data.jsonl \
+                    --data_path=/data/data/processed_data/data.jsonl \
                     --output_dir="$tmp_model" \
                     --num_epochs={epoch_num} \
                     --effective_batch_size=3840 \

--- a/standalone/standalone.tpl
+++ b/standalone/standalone.tpl
@@ -1195,7 +1195,7 @@ def create_data_job(
 {{exec_data_processing_op_command}}
 """
     exec_data_processing_op_args = f"""
-data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg={DATA_PVC_SDG_PATH}, model={DATA_PVC_SDG_PATH}, processed_data={PREPROCESSED_DATA_PATH})
+data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_MODEL_PATH}", processed_data="{PREPROCESSED_DATA_PATH}")
 """
 
     data_container = kubernetes.client.V1Container(


### PR DESCRIPTION
@MichaelClifford ptal
* the data-processing-op arg fix needs to go in pipeline.py, too, otherwise `make standalone` reverts the fix
* the data_dir is wrong in standalone.py (there's no equivalent in pipeline.py afaict) - so training pods were failing bc they were looking for `data.jsonl` in the wrong path.
Training is progessing now for me. 